### PR TITLE
fix(workshop-example): add ipfs network to hello world example

### DIFF
--- a/examples/cactus-workshop-examples-2022-11-14/README.md
+++ b/examples/cactus-workshop-examples-2022-11-14/README.md
@@ -7,39 +7,36 @@ WARNING: This code IS NOT production-ready nor secure! Namely, cross-site script
 
 ``src/main/typescript/hello-world.ts``
 
-Creates an APIServer and a Keychain Memory client. The server interacts with the key pairs in the Keychain Memory.
+Creates an APIServer listening on port 3001 that exposes the endpoints of the ingested plugins - for demonstration purposes we use only one plugin, the cactus-plugin-object-store-ipfs. This plugin interacts with an underlying IPFS network (a simple key-value store).
 
-Runs with the following command ``npx ts-node src/main/typescript/hello-world.ts``
+Run the file with the following command ``npx ts-node src/main/typescript/hello-world.ts``
 
-The implemented interactions are:
-- POST "/set-kcm", which sets a new key-value pair.
+To interact with the IPFS connector through the APIServer follow the next commands:
+- POST `/api/v1/plugins/@hyperledger/cactus-plugin-object-store-ipfs/set-object`, which sets a new key-value pair.
     ```
     curl --header "Content-Type: application/json" \
         --request POST \
         --data '{"key":"1234","value":"xyz"}' \
-        http://localhost:8000/set-kcm
+        http://localhost:3001/api/v1/plugins/@hyperledger/cactus-plugin-object-store-ipfs/set-object
     ```
-- GET "/get-kcm/:key", which gets a key-value pair.
-    ```
-    curl --header "Content-Type: application/json" \
-        --request GET \
-        --data '{"key":"1234"}' \
-        http://localhost:8000/get-kcm/1234
-    ```
-- DELETE "/delete/:key", which deletes a key-value pair.
+
+- POST `/api/v1/plugins/@hyperledger/cactus-plugin-object-store-ipfs/get-object`, which gets a key-value pair.
     ```
     curl --header "Content-Type: application/json" \
-        --request POST \
+        --request POST  \
         --data '{"key":"1234"}' \
-        http://localhost:8000/delete-kcm/1234
+        http://localhost:3001/api/v1/plugins/@hyperledger/cactus-plugin-object-store-ipfs/get-object
     ```
+
 - GET "/has-key/:key", which checks if a key-value pair exits in the client.
     ```
     curl --header "Content-Type: application/json" \
-        --request GET \
+        --request POST  \
         --data '{"key":"1234"}' \
-        http://localhost:8000/has-key/1234
+        http://localhost:3001/api/v1/plugins/@hyperledger/cactus-plugin-object-store-ipfs/has-object
     ```
+
+*NOTE: other carachters might appear in the output of the commands since we should insert the values in base64. For demo purposes we don't make the conversion.*
 
 ## Hyperledger Cacti Workshop Examples - Simple Consortium
 
@@ -65,3 +62,4 @@ This example package works with version 1.0.0 of ``@hyperledger/cactus-test-tool
 - Rafael Belchior
 - Mónica Gomez
 - Abhinav Srivastava
+- André Augusto

--- a/examples/cactus-workshop-examples-2022-11-14/src/main/typescript/hello-world.ts
+++ b/examples/cactus-workshop-examples-2022-11-14/src/main/typescript/hello-world.ts
@@ -1,39 +1,30 @@
 // WARNING: This code IS NOT production-ready nor secure! Namely, cross-site scripting is possible if user input is not sanitized.
 import { ApiServer, ConfigService } from "@hyperledger/cactus-cmd-api-server";
 import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
+import { GoIpfsTestContainer } from "@hyperledger/cactus-test-tooling";
+import { create } from "ipfs-http-client";
+import { createServer } from "http";
+import { v4 as uuidv4 } from "uuid";
 import {
   PluginImportAction,
   PluginImportType,
 } from "@hyperledger/cactus-core-api";
-import express, { Request, Response } from "express";
-import cors from "cors";
-import bodyParser from "body-parser";
-import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
 const log: Logger = LoggerProvider.getOrCreate({
   label: "cacti-node-test-app",
   level: "info",
 });
 
-const app = express();
-app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
-const PORT = 8000;
-
 const main = async () => {
-  // Handling GET / Request
-  app.get("/", (req: Request, res: Response) => {
-    log.info("Cacti: Hello World");
-    res.send("Welcome to the Hello World server!");
-  });
+  // start an IPFS network (a key-value store) for demonstration purposes
+  const ipfsNetwork = new GoIpfsTestContainer({});
+  await ipfsNetwork.start();
 
-  // Server port setup
-  app.listen(PORT, () => {
-    log.info(`Application running on port ${PORT}`);
-    console.log(
-      "The application is listening " + "on port http://localhost:" + PORT,
-    );
+  // retrieve the url so that the IPFS connector plugin is
+  // able to connect to the IPFS network. This will be used
+  // as an argument for the plugin bellow
+  const ipfsClientOrOptions = create({
+    url: await ipfsNetwork.getApiUrl(),
   });
 
   //Configuring APIServer
@@ -41,26 +32,31 @@ const main = async () => {
   const apiServerOptions: any = await configService.newExampleConfig();
   apiServerOptions.configFile = "";
   apiServerOptions.authorizationProtocol = "NONE";
+
+  //The port where the APIServer will be listening
   apiServerOptions.apiPort = 3001;
   apiServerOptions.cockpitPort = 3100;
   apiServerOptions.grpcPort = 5000;
-  apiServerOptions.apiTlsEnabled = true; //Disable TLS (or provide TLS certs for secure HTTP if you are deploying to production)
+  apiServerOptions.apiTlsEnabled = false; //Disable TLS (or provide TLS certs for secure HTTP if you are deploying to production)
   apiServerOptions.plugins = [
-    //Hyperledger cacti add plugin keychain-aws-sm
+    //add plugins that will be exposed by the API Server
     {
-      packageName: "@hyperledger/cactus-plugin-keychain-memory",
+      packageName: "@hyperledger/cactus-plugin-object-store-ipfs",
       type: PluginImportType.Remote,
       action: PluginImportAction.Install,
       options: {
-        instanceId: "keychain",
-        keychainId: "1",
+        parentDir: `/${uuidv4()}/${uuidv4()}/`,
+        logLevel: "DEBUG",
+        instanceId: uuidv4(),
+        ipfsClientOrOptions,
       },
     },
   ];
+
   const config = await configService.newExampleConfigConvict(apiServerOptions);
 
-  //Creating Cacti APIServer
   const apiServer = new ApiServer({
+    httpServerApi: createServer(),
     config: config.getProperties(),
   });
 
@@ -68,74 +64,12 @@ const main = async () => {
   apiServer.start();
 };
 
-const client = async () => {
-  //Creating keychain memory client
-  const apiClient = new PluginKeychainMemory({
-    instanceId: "keychain",
-    keychainId: "1",
-    logLevel: "info",
-  });
-
-  //Setting a key value pair
-  app.post("/set-kcm", async (req: Request, res: Response) => {
-    const key = req.body.key;
-    const value = req.body.value;
-    try {
-      // TODO Security: Sanitize user input
-      await apiClient.set(key, value);
-      log.info("Key value pair set; Key: " + key + " Value: " + value);
-      res.status(201).end();
-    } catch (err: any) {
-      res.status(404).send("error setting key");
-    }
-  });
-
-  //Getting a key value pair
-  app.get("/get-kcm/:key", async (req: Request, res: Response) => {
-    try {
-      const { key } = req.params;
-      // TODO Security: Sanitize user input
-      const response = await apiClient.get(key);
-      log.info("Got key-value pair: (" + key + ", " + response + ")");
-      res.end(response);
-    } catch (err: any) {
-      res.status(404).send("error getting key");
-    }
-  });
-
-  //Deleting a key value pair
-  app.post("/delete-kcm/:key", async (req: Request, res: Response) => {
-    try {
-      const { key } = req.params;
-      // TODO Security: Sanitize user input
-      await apiClient.delete(key);
-      log.info("Deleted key: " + key);
-      res.status(200).end();
-    } catch (err: unknown) {
-      res.status(404).send("error deleting key");
-    }
-  });
-
-  //Checking if a specific key exists
-  app.get("/has-key/:key", async (req: Request, res: Response) => {
-    try {
-      const { key } = req.params;
-      const response = await apiClient.has(key);
-      log.info("Key exists? " + response);
-      res.status(200).send(response);
-    } catch (err: unknown) {
-      res.status(404).send("error checking existence of key");
-    }
-  });
-};
-
 export async function launchApp(): Promise<void> {
   try {
     await main();
-    await client();
-    log.info(`Cacti Keychain example ran OK `);
+    log.info(`Cacti Hello World example ran OK `);
   } catch (ex) {
-    log.error(`Cacti Keychain example crashed: `, ex);
+    log.error(`Cacti Hello World example crashed: `, ex);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Registering the express app in the keychain-memory plugin was not exposing the created endpoints. So I added an IPFS network and the IPFS connector plugin that is now being exposed by the API Server.

Updated README with the new instructions to interact with the endpoints.

Signed-off-by: André Augusto <andre.augusto@tecnico.ulisboa.pt>